### PR TITLE
Add Ctrl+Enter / Cmd+Enter shortcut to send requests in rep+

### DIFF
--- a/js/ui/main-ui.js
+++ b/js/ui/main-ui.js
@@ -256,6 +256,18 @@ export function initUI() {
             elements.rawRequestInput.innerText = rawReqTextarea.value;
             // Trigger highlight update if needed, or just keep sync
         });
+
+        // Hotkey: Ctrl/Cmd + Enter in raw textarea → Send request
+        rawReqTextarea.addEventListener('keydown', (e) => {
+            const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+            const modKey = isMac ? e.metaKey : e.ctrlKey;
+            if (modKey && e.key === 'Enter') {
+                e.preventDefault();
+                if (elements.sendBtn) {
+                    elements.sendBtn.click();
+                }
+            }
+        });
     }
 
     // Layout Toggle

--- a/js/ui/ui-utils.js
+++ b/js/ui/ui-utils.js
@@ -200,6 +200,16 @@ export function setupUndoRedo() {
         const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
         const modKey = isMac ? e.metaKey : e.ctrlKey;
 
+        // Hotkey: Ctrl/Cmd + Enter → Send request
+        if (modKey && e.key === 'Enter') {
+            e.preventDefault();
+            if (elements.sendBtn) {
+                elements.sendBtn.click();
+            }
+            return;
+        }
+
+        // Hotkeys: Undo / Redo
         if (modKey && e.key === 'z' && !e.shiftKey && !e.altKey) {
             e.preventDefault();
             undo();


### PR DESCRIPTION
Implemented a keyboard shortcut to send requests in **rep+**, making it easier to quickly replay requests.

## Behavior
- **Pretty request editor (`raw-request-input`)**: Press **Ctrl+Enter** (Windows/Linux) or **Cmd+Enter** (macOS) to send the request, same as clicking Send.  
- **Raw request textarea (`raw-request-textarea`)**: Same shortcut works here as well.

## Technical details
- `js/ui/ui-utils.js`: Extended the keydown handler on `elements.rawRequestInput` to handle Ctrl/Cmd+Enter before undo/redo, calling `elements.sendBtn.click()`.  
- `js/ui/main-ui.js`: Added a keydown handler on `raw-request-textarea` to mirror the same shortcut and trigger `elements.sendBtn.click()`.