### PR TITLE
Add Duplicate Request Removal

### DIFF
--- a/css/panel.css
+++ b/css/panel.css
@@ -164,15 +164,144 @@ body.theme-transitioning img {
 
 .search-container {
     display: flex;
-    gap: 4px;
+    gap: var(--spacing-xs);
     margin-bottom: 6px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+/* Responsive improvements */
+@media (max-width: 500px) {
+    .search-container {
+        gap: var(--spacing-sm);
+    }
+    
+    .primary-actions {
+        flex-wrap: wrap;
+        gap: var(--spacing-xs);
+    }
+    
+    .search-input-wrapper {
+        min-width: 120px;
+    }
+}
+
+/* Very small screens: stack vertically */
+@media (max-width: 350px) {
+    .search-container {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    
+    .search-input-wrapper {
+        min-width: 100%;
+        width: 100%;
+    }
+    
+    .primary-actions {
+        width: 100%;
+        justify-content: space-between;
+    }
+    
+    .more-menu-wrapper {
+        width: 100%;
+    }
+    
+    .more-menu {
+        right: auto;
+        left: 0;
+        width: 100%;
+    }
 }
 
 .search-input-wrapper {
     position: relative;
     flex: 1;
+    min-width: 150px;
     display: flex;
     align-items: center;
+}
+
+.primary-actions {
+    display: flex;
+    gap: var(--spacing-xs);
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.more-menu-wrapper {
+    position: relative;
+    flex-shrink: 0;
+}
+
+.more-menu-btn {
+    position: relative;
+}
+
+.more-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    background: var(--sidebar-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    min-width: 180px;
+    z-index: 1000;
+    padding: var(--spacing-xs) 0;
+    display: flex;
+    flex-direction: column;
+    animation: slideDown 0.2s ease-out;
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.more-menu.hidden {
+    display: none;
+}
+
+.more-menu-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm) var(--spacing-md);
+    background: transparent;
+    border: none;
+    color: var(--text-color);
+    cursor: pointer;
+    font-size: 13px;
+    text-align: left;
+    width: 100%;
+    transition: background-color 0.2s ease;
+    white-space: nowrap;
+}
+
+.more-menu-item:hover {
+    background: var(--hover-bg);
+}
+
+.more-menu-item:active {
+    background: var(--input-bg);
+}
+
+.more-menu-item svg {
+    flex-shrink: 0;
+    opacity: 0.8;
+    width: 14px;
+    height: 14px;
+}
+
+.more-menu-item span {
+    flex: 1;
 }
 
 #search-bar,
@@ -1565,6 +1694,17 @@ tr.selected {
 .icon-btn:disabled {
     opacity: 0.3;
     cursor: default;
+}
+
+.icon-btn.active {
+    background: var(--hover-bg);
+    color: var(--accent-color);
+    border-color: var(--accent-color);
+}
+
+.icon-btn.active:hover {
+    background: var(--hover-bg);
+    color: var(--accent-color);
 }
 
 /* Custom Tooltip */

--- a/js/features/extractors/ui.js
+++ b/js/features/extractors/ui.js
@@ -859,7 +859,7 @@ export function initExtractorUI() {
                 // Hide progress bar and steps after a delay
                 setTimeout(() => {
                     if (isScanComplete) {
-                        extractorProgress.style.display = 'none';
+                    extractorProgress.style.display = 'none';
                         if (scanSteps) scanSteps.style.display = 'none';
                     }
                 }, 2000);

--- a/js/main.js
+++ b/js/main.js
@@ -119,6 +119,43 @@ document.addEventListener('DOMContentLoaded', () => {
         elements.sendBtn.addEventListener('click', handleSendRequest);
     }
 
+    // Remove Duplicates Toggle
+    if (elements.removeDuplicatesBtn) {
+        // Load saved preference (default: true/enabled)
+        const removeDuplicatesEnabled = localStorage.getItem('rep_remove_duplicates') !== 'false';
+        updateRemoveDuplicatesButton(removeDuplicatesEnabled);
+        
+        elements.removeDuplicatesBtn.addEventListener('click', () => {
+            const currentState = localStorage.getItem('rep_remove_duplicates') !== 'false';
+            const newState = !currentState;
+            
+            localStorage.setItem('rep_remove_duplicates', newState.toString());
+            updateRemoveDuplicatesButton(newState);
+            
+            // If enabling, remove existing duplicates
+            if (newState) {
+                const removedCount = actions.request.removeDuplicates();
+                if (removedCount > 0) {
+                    console.log(`Removed ${removedCount} duplicate request${removedCount !== 1 ? 's' : ''}`);
+                } else {
+                    console.log('No duplicates found to remove');
+                }
+            }
+        });
+    }
+    
+    function updateRemoveDuplicatesButton(enabled) {
+        if (!elements.removeDuplicatesBtn) return;
+        
+        if (enabled) {
+            elements.removeDuplicatesBtn.classList.add('active');
+            elements.removeDuplicatesBtn.title = 'Remove duplicate requests (enabled)';
+        } else {
+            elements.removeDuplicatesBtn.classList.remove('active');
+            elements.removeDuplicatesBtn.title = 'Remove duplicate requests (disabled)';
+        }
+    }
+
     // Clear All
     if (elements.clearAllBtn) {
         elements.clearAllBtn.addEventListener('click', () => {
@@ -138,7 +175,24 @@ document.addEventListener('DOMContentLoaded', () => {
         elements.toggleObjectsBtn.addEventListener('click', toggleAllObjects);
     }
 
-    // Export/Import
+    // More Menu Toggle
+    const moreMenuBtn = document.getElementById('more-menu-btn');
+    const moreMenu = document.getElementById('more-menu');
+    if (moreMenuBtn && moreMenu) {
+        moreMenuBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            moreMenu.classList.toggle('hidden');
+        });
+        
+        // Close menu when clicking outside
+        document.addEventListener('click', (e) => {
+            if (!moreMenu.contains(e.target) && e.target !== moreMenuBtn) {
+                moreMenu.classList.add('hidden');
+            }
+        });
+    }
+
+    // Export/Import (now in more menu)
     if (elements.exportBtn) elements.exportBtn.addEventListener('click', exportRequests);
     if (elements.importBtn) elements.importBtn.addEventListener('click', () => elements.importFile.click());
     if (elements.importFile) {
@@ -146,6 +200,17 @@ document.addEventListener('DOMContentLoaded', () => {
             if (e.target.files.length > 0) {
                 importRequests(e.target.files[0]);
                 e.target.value = ''; // Reset
+            }
+        });
+    }
+    
+    // Close more menu after clicking an item
+    if (moreMenu) {
+        moreMenu.addEventListener('click', (e) => {
+            if (e.target.closest('.more-menu-item')) {
+                setTimeout(() => {
+                    moreMenu.classList.add('hidden');
+                }, 100);
             }
         });
     }

--- a/js/ui/main-ui.js
+++ b/js/ui/main-ui.js
@@ -31,6 +31,7 @@ export function initUI() {
     elements.screenshotBtn = document.getElementById('screenshot-btn');
     elements.multiTabBtn = document.getElementById('multi-tab-btn');
     elements.contextMenu = document.getElementById('context-menu');
+    elements.removeDuplicatesBtn = document.getElementById('remove-duplicates-btn');
     elements.clearAllBtn = document.getElementById('clear-all-btn');
     elements.exportBtn = document.getElementById('export-btn');
     elements.importBtn = document.getElementById('import-btn');

--- a/panel.html
+++ b/panel.html
@@ -28,69 +28,87 @@
         <div class="sidebar">
             <div class="sidebar-header">
                 <div class="search-container">
+                    <!-- Primary Actions: Search and Most Used Buttons -->
                     <div class="search-input-wrapper">
                         <input type="text" id="search-bar" placeholder="Filter requests...">
                         <button id="regex-toggle" class="regex-toggle-inline" title="Toggle Regex Mode">
                             <span class="regex-icon">.*</span>
                         </button>
                     </div>
-                    <button id="clear-all-btn" class="icon-btn" style="margin-left: 4px;">
-                        <svg viewBox="0 0 24 24" width="14" height="14">
-                            <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                                fill="currentColor" />
-                        </svg>
-                    </button>
-                    <button id="toggle-groups-btn" class="icon-btn" title="Collapse/Expand All Groups">
-                        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-                            <path
-                                d="M12 5.83L15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z" />
-                        </svg>
-                    </button>
-                    <button id="toggle-sidebar-btn" class="icon-btn" title="Hide sidebar" aria-label="Hide sidebar">
-                        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-                            <path d="M4 4h4v16H4V4zm5 0h11v2H9V4zm0 6h11v2H9v-2zm0 6h11v2H9v-2z" />
-                        </svg>
-                    </button>
-                    <div class="divider-vertical"
-                        style="width: 1px; height: 20px; background: var(--border-color); margin: 0 4px;"></div>
-                    <button id="settings-btn" class="icon-btn">
-                        <svg viewBox="0 0 24 24" width="14" height="14">
-                            <path
-                                d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 0 1 7 7h1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v1a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h1a7 7 0 0 1 7-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 0 1 2-2M7.5 13a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5m9 0a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5"
-                                fill="currentColor" />
-                        </svg>
-                    </button>
-                    <button id="import-btn" class="icon-btn">
-                        <svg viewBox="0 0 24 24" width="14" height="14">
-                            <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" fill="currentColor" />
-                        </svg>
-                    </button>
-                    <button id="export-btn" class="icon-btn">
-                        <svg viewBox="0 0 24 24" width="14" height="14">
-                            <path d="M9 16h6v-6h4l-7-7-7 7h4zm-4 2h14v2H5z" fill="currentColor" />
-                        </svg>
-                    </button>
-                    <button id="extractor-btn" class="icon-btn" title="Extract Secrets & Endpoints">
-                        <svg viewBox="0 0 24 24" width="14" height="14">
-                            <path
-                                d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z"
-                                fill="currentColor" />
-                        </svg>
-                    </button>
-                    <button id="llm-chat-toggle-btn" class="icon-btn ai-icon-btn" title="Rep+ AI Assistance - Ask AI about the request">
-                        <svg class="ai-icon" viewBox="0 0 24 24" width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <!-- AI Brain/Sparkle Icon -->
-                            <path d="M12 2C8.13 2 5 5.13 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.87-3.13-7-7-7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-                            <circle cx="9" cy="9" r="1" fill="currentColor"/>
-                            <circle cx="15" cy="9" r="1" fill="currentColor"/>
-                            <path d="M9 13c.5.5 1.5 1 3 1s2.5-.5 3-1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-                            <!-- Sparkles -->
-                            <circle class="ai-sparkle ai-sparkle-1" cx="4" cy="6" r="0.8" fill="currentColor"/>
-                            <circle class="ai-sparkle ai-sparkle-2" cx="20" cy="8" r="0.8" fill="currentColor"/>
-                            <circle class="ai-sparkle ai-sparkle-3" cx="6" cy="18" r="0.8" fill="currentColor"/>
-                            <circle class="ai-sparkle ai-sparkle-4" cx="18" cy="20" r="0.8" fill="currentColor"/>
-                        </svg>
-                    </button>
+                    <div class="primary-actions">
+                        <button id="remove-duplicates-btn" class="icon-btn" title="Remove duplicate requests (enabled by default)">
+                            <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                                <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
+                            </svg>
+                        </button>
+                        <button id="clear-all-btn" class="icon-btn" title="Clear all requests">
+                            <svg viewBox="0 0 24 24" width="14" height="14">
+                                <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                    fill="currentColor" />
+                            </svg>
+                        </button>
+                        <button id="toggle-groups-btn" class="icon-btn" title="Collapse/Expand All Groups">
+                            <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                                <path
+                                    d="M12 5.83L15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z" />
+                            </svg>
+                        </button>
+                        <button id="llm-chat-toggle-btn" class="icon-btn ai-icon-btn" title="Rep+ AI Assistance">
+                            <svg class="ai-icon" viewBox="0 0 24 24" width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M12 2C8.13 2 5 5.13 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.87-3.13-7-7-7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                                <circle cx="9" cy="9" r="1" fill="currentColor"/>
+                                <circle cx="15" cy="9" r="1" fill="currentColor"/>
+                                <path d="M9 13c.5.5 1.5 1 3 1s2.5-.5 3-1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                                <circle class="ai-sparkle ai-sparkle-1" cx="4" cy="6" r="0.8" fill="currentColor"/>
+                                <circle class="ai-sparkle ai-sparkle-2" cx="20" cy="8" r="0.8" fill="currentColor"/>
+                                <circle class="ai-sparkle ai-sparkle-3" cx="6" cy="18" r="0.8" fill="currentColor"/>
+                                <circle class="ai-sparkle ai-sparkle-4" cx="18" cy="20" r="0.8" fill="currentColor"/>
+                            </svg>
+                        </button>
+                        <button id="toggle-sidebar-btn" class="icon-btn" title="Hide sidebar">
+                            <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                                <path d="M4 4h4v16H4V4zm5 0h11v2H9V4zm0 6h11v2H9v-2zm0 6h11v2H9v-2z" />
+                            </svg>
+                        </button>
+                    </div>
+                    <!-- Secondary Actions: More Menu -->
+                    <div class="more-menu-wrapper">
+                        <button id="more-menu-btn" class="icon-btn more-menu-btn" title="More options">
+                            <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                                <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+                            </svg>
+                        </button>
+                        <div id="more-menu" class="more-menu hidden">
+                            <button id="settings-btn" class="more-menu-item">
+                                <svg viewBox="0 0 24 24" width="14" height="14">
+                                    <path
+                                        d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 0 1 7 7h1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v1a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h1a7 7 0 0 1 7-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 0 1 2-2M7.5 13a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5m9 0a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5"
+                                        fill="currentColor" />
+                                </svg>
+                                <span>Settings</span>
+                            </button>
+                            <button id="import-btn" class="more-menu-item">
+                                <svg viewBox="0 0 24 24" width="14" height="14">
+                                    <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" fill="currentColor" />
+                                </svg>
+                                <span>Import</span>
+                            </button>
+                            <button id="export-btn" class="more-menu-item">
+                                <svg viewBox="0 0 24 24" width="14" height="14">
+                                    <path d="M9 16h6v-6h4l-7-7-7 7h4zm-4 2h14v2H5z" fill="currentColor" />
+                                </svg>
+                                <span>Export</span>
+                            </button>
+                            <button id="extractor-btn" class="more-menu-item" title="Extract secrets, endpoints, parameters, and search responses">
+                                <svg viewBox="0 0 24 24" width="14" height="14">
+                                    <path
+                                        d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z"
+                                        fill="currentColor" />
+                                </svg>
+                                <span>Extractor</span>
+                            </button>
+                        </div>
+                    </div>
                     <input type="file" id="import-file" accept=".json" style="display: none;">
                 </div>
                 <div class="filters">


### PR DESCRIPTION
Adds an automatic duplicate request removal feature to keep the request list clean.

**Key points:**
- Enabled by default, with a **Remove Duplicates** toggle in the sidebar
- Prevents duplicate requests in real time
- Removes existing duplicates when re-enabled
- Persists user preference via `localStorage`
- Duplicates are detected using method, URL, normalized headers, and body

**Why:**
- Reduces noise in captured requests
- Improves performance and UX
- Keeps focus on unique requests

**UI:**
- Toggle button shows active state
- Request list refreshes correctly after cleanup