### PR TITLE
Fix export to include captured response bodies

### DIFF
--- a/js/ui/ui-utils.js
+++ b/js/ui/ui-utils.js
@@ -1713,7 +1713,7 @@ export function exportRequests() {
                 response: {
                     status: req.response.status,
                     headers: resHeadersObj,
-                    body: req.response.content ? req.response.content.text : ""
+                    body: req.response?.content?.text || req.responseBody || ""
                 },
                 timestamp: req.capturedAt
             };


### PR DESCRIPTION
Export now falls back to request.responseBody when response.content.text is missing, so current‑tab captures include response bodies in JSON.
Fixes missing response.body in exported files for requests that clearly have a response in the UI.