### PR TITLE
feat: add "Apply & Send" button to AI Chat

### DIFF
--- a/css/panel.css
+++ b/css/panel.css
@@ -5066,9 +5066,9 @@ pre {
 
 .llm-chat-apply-send-btn {
     padding: 6px 12px;
-    background: var(--primary-color);
-    color: #fff;
-    border: 1px solid var(--primary-color);
+    background: var(--accent-color);
+    color: #000;
+    border: 1px solid var(--accent-color);
     border-radius: var(--radius-sm);
     font-size: 12px;
     font-weight: 500;
@@ -5078,10 +5078,11 @@ pre {
 }
 
 .llm-chat-apply-send-btn:hover:not(:disabled) {
-    background: var(--primary-color);
-    filter: brightness(1.1);
+    background: var(--accent-color);
+    filter: brightness(1.2);
+    opacity: 1;
     transform: translateY(-1px);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 .llm-chat-apply-send-btn:active:not(:disabled) {

--- a/css/panel.css
+++ b/css/panel.css
@@ -5064,6 +5064,47 @@ pre {
     color: #fff;
 }
 
+.llm-chat-apply-send-btn {
+    padding: 6px 12px;
+    background: var(--primary-color);
+    color: #fff;
+    border: 1px solid var(--primary-color);
+    border-radius: var(--radius-sm);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+
+.llm-chat-apply-send-btn:hover:not(:disabled) {
+    background: var(--primary-color);
+    filter: brightness(1.1);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.llm-chat-apply-send-btn:active:not(:disabled) {
+    transform: translateY(0);
+}
+
+.llm-chat-apply-send-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.llm-chat-apply-send-btn.applied {
+    background: var(--success-color, #4caf50);
+    border-color: var(--success-color, #4caf50);
+    color: #fff;
+}
+
+.llm-chat-apply-send-btn.error {
+    background: var(--error-color, #f44336);
+    border-color: var(--error-color, #f44336);
+    color: #fff;
+}
+
 .llm-chat-feedback {
     display: inline-block;
     padding: 4px 8px;

--- a/js/features/llm-chat/index.js
+++ b/js/features/llm-chat/index.js
@@ -3,6 +3,7 @@ import { getAISettings, streamChatWithMessages } from '../ai/core.js';
 import { state, actions } from '../../core/state.js';
 import { events, EVENT_NAMES } from '../../core/events.js';
 import { formatRawResponse } from '../../network/response-parser.js';
+import { handleSendRequest } from '../../network/handler.js';
 import { highlightHTTP } from '../../core/utils/network.js';
 import { elements } from '../../ui/main-ui.js';
 
@@ -891,6 +892,42 @@ export function setupLLMChat(elements) {
                                 };
                                 
                                 actionsDiv.appendChild(button);
+                                // Add Apply & Send button
+                                const sendButton = document.createElement('button');
+                                sendButton.className = 'llm-chat-apply-send-btn';
+                                sendButton.textContent = 'Apply & Send';
+                                sendButton.title = 'Apply changes and send request immediately';
+                                
+                                sendButton.onclick = async () => {
+                                    if (applyRequestModification(suggestion)) {
+                                        sendButton.textContent = '✓ Sending...';
+                                        sendButton.disabled = true;
+                                        sendButton.classList.add('applied');
+                                        
+                                        // Update the other button too
+                                        button.textContent = '✓ Applied';
+                                        button.disabled = true;
+                                        button.classList.add('applied');
+                                        
+                                        try {
+                                            await handleSendRequest();
+                                            sendButton.textContent = '✓ Sent';
+                                        } catch (e) {
+                                            sendButton.textContent = '✗ Send Failed';
+                                            sendButton.classList.add('error');
+                                            console.error('Apply & Send failed:', e);
+                                        }
+                                    } else {
+                                        sendButton.textContent = '✗ Failed';
+                                        sendButton.classList.add('error');
+                                        setTimeout(() => {
+                                            sendButton.textContent = 'Apply & Send';
+                                            sendButton.classList.remove('error');
+                                        }, 2000);
+                                    }
+                                };
+                                
+                                actionsDiv.appendChild(sendButton);
                             });
                             
                             messageContainer.appendChild(actionsDiv);

--- a/js/features/llm-chat/index.js
+++ b/js/features/llm-chat/index.js
@@ -895,7 +895,7 @@ export function setupLLMChat(elements) {
                                 // Add Apply & Send button
                                 const sendButton = document.createElement('button');
                                 sendButton.className = 'llm-chat-apply-send-btn';
-                                sendButton.textContent = 'Apply & Send';
+                                sendButton.textContent = 'Apply Request & Send';
                                 sendButton.title = 'Apply changes and send request immediately';
                                 
                                 sendButton.onclick = async () => {


### PR DESCRIPTION
the AI chat only allowed users to "Apply Request Changes" then user has to click on Send button. This PR adds a new "Apply & Send" button to allow users to immediately execute suggested requests in one step. Most of the time, users simply ask and send instead of: ask, apply,send

Key Changes:
- New "Apply & Send" Action: Added a button that combines applying the AI's suggested payload to the raw request editor and immediately sending the request.
- Improved Workflow: Users no longer have to manually click "Send" after applying an AI suggestion; the new button handles the full sequence.
- Styling Consistency: Updated CSS to ensure both action buttons have a matching, high-visibility style.
<img width="291" height="64" alt="image" src="https://github.com/user-attachments/assets/9dbe0495-5fac-4b85-a857-e3a9711f7de9" />