### PR TITLE
feat: Implement route override send and UI

### DIFF
--- a/css/panel.css
+++ b/css/panel.css
@@ -1410,6 +1410,37 @@ body.theme-transitioning img {
     box-sizing: border-box;
 }
 
+.url-mapping-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.url-mapping-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.url-mapping-row .form-control {
+    width: auto;
+    flex: 1;
+}
+
+.url-mapping-arrow {
+    color: var(--text-color);
+    opacity: 0.6;
+}
+
+.url-mapping-remove {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .form-row {
     display: flex;
     gap: 10px;
@@ -1708,11 +1739,13 @@ tr.selected {
 }
 
 /* Custom Tooltip */
-.icon-btn[data-tooltip] {
+.icon-btn[data-tooltip],
+.secondary-btn[data-tooltip] {
     position: relative;
 }
 
-.icon-btn[data-tooltip]:hover::after {
+.icon-btn[data-tooltip]:hover::after,
+.secondary-btn[data-tooltip]:hover::after {
     content: attr(data-tooltip);
     position: absolute;
     bottom: 100%;
@@ -2174,6 +2207,10 @@ pre {
     cursor: pointer;
     margin: 5px;
     align-self: flex-start;
+}
+
+.send-btn-local {
+    margin-left: 8px;
 }
 
 .status-badge {
@@ -5316,4 +5353,3 @@ pre {
         transform: translateX(0);
     }
 }
-

--- a/js/main.js
+++ b/js/main.js
@@ -275,6 +275,15 @@ document.addEventListener('DOMContentLoaded', () => {
             urlMappingModal.style.display = 'block';
         });
     }
+    
+    if (urlMappingModal) {
+        const urlMappingCloseBtn = urlMappingModal.querySelector('.close-modal');
+        if (urlMappingCloseBtn) {
+            urlMappingCloseBtn.addEventListener('click', () => {
+                urlMappingModal.style.display = 'none';
+            });
+        }
+    }
 
     if (addUrlMappingBtn) {
         addUrlMappingBtn.addEventListener('click', () => {

--- a/js/network/url-mapping.js
+++ b/js/network/url-mapping.js
@@ -1,0 +1,40 @@
+const STORAGE_KEY = 'rep_url_mappings';
+
+
+function normalizeMappings(mappings) {
+    if (!Array.isArray(mappings)) return [];
+    return mappings
+        .map(mapping => ({
+            from: typeof mapping?.from === 'string' ? mapping.from.trim() : '',
+            to: typeof mapping?.to === 'string' ? mapping.to.trim() : ''
+        }))
+        .filter(mapping => mapping.from && mapping.to);
+}
+
+export function getUrlMappings() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === null) return [];
+
+    try {
+        const parsed = JSON.parse(stored);
+        return normalizeMappings(parsed);
+    } catch (err) {
+        localStorage.removeItem(STORAGE_KEY);
+        return [];
+    }
+}
+
+export function saveUrlMappings(mappings) {
+    const normalized = normalizeMappings(mappings);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+}
+
+export function applyUrlMappings(url, mappings = getUrlMappings()) {
+    for (const mapping of mappings) {
+        if (!mapping.from || !mapping.to) continue;
+        if (url.startsWith(mapping.from)) {
+            return mapping.to + url.slice(mapping.from.length);
+        }
+    }
+    return url;
+}

--- a/js/ui/main-ui.js
+++ b/js/ui/main-ui.js
@@ -16,6 +16,7 @@ export function initUI() {
     elements.rawRequestInput = document.getElementById('raw-request-input');
     elements.useHttpsCheckbox = document.getElementById('use-https');
     elements.sendBtn = document.getElementById('send-btn');
+    elements.sendBtnLocal = document.getElementById('send-btn-local');
     elements.rawResponseDisplay = document.getElementById('raw-response-display');
     elements.rawResponseText = document.getElementById('raw-response-text');
     elements.hexResponseDisplay = document.getElementById('res-hex-display');

--- a/panel.html
+++ b/panel.html
@@ -87,6 +87,12 @@
                                 </svg>
                                 <span>Settings</span>
                             </button>
+                            <button id="url-mapping-btn" class="more-menu-item">
+                                <svg viewBox="0 0 24 24" width="14" height="14">
+                                    <path d="M7.5 12a4.5 4.5 0 0 1 4.5-4.5h3v-2h-3a6.5 6.5 0 1 0 0 13h3v-2h-3A4.5 4.5 0 0 1 7.5 12zm6-4.5h-3v2h3a4.5 4.5 0 1 1 0 9h-3v2h3a6.5 6.5 0 0 0 0-13z" fill="currentColor" />
+                                </svg>
+                                <span>Route Override</span>
+                            </button>
                             <button id="import-btn" class="more-menu-item">
                                 <svg viewBox="0 0 24 24" width="14" height="14">
                                     <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" fill="currentColor" />
@@ -268,6 +274,7 @@
                                 </svg>
                             </button>
                             <button id="send-btn" class="primary-btn">Send</button>
+                            <button id="send-btn-local" class="secondary-btn send-btn-local" data-tooltip="Send with route override" title="Send with route override">Send-Override</button>
                         </div>
                     </div>
                     <div class="pane-tabs">
@@ -711,6 +718,31 @@
             </div>
             <div class="modal-footer">
                 <button id="save-settings-btn" class="primary-btn">Save</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- URL Mapping Modal -->
+    <div id="url-mapping-modal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Route Override</h3>
+                <button class="close-modal">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label>Replace URL prefixes when sending locally</label>
+                    <div id="url-mapping-list" class="url-mapping-list"></div>
+                </div>
+                <button id="add-url-mapping-btn" class="secondary-btn" type="button">Add Override</button>
+                <div class="form-group">
+                    <label>Paste overrides (key => value per line)</label>
+                    <textarea id="url-mapping-bulk-input" class="form-control" rows="4" placeholder="https://api.example.com => http://localhost:9000"></textarea>
+                    <button id="apply-url-mapping-bulk-btn" class="secondary-btn" type="button">Apply</button>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="save-url-mapping-btn" class="primary-btn">Save</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
 **Key Points**
  - Route Override lets you reroute captured requests to local services by prefix replacement.
  - Send-Override sends the current request using the configured overrides.
  - Bulk paste with => per line updates/overwrites existing keys and validates required fields.

  **Why**
  - When you run a local backend for debugging, you often need to replay the same requests without hitting production. Route Override
    makes that quick and reliable.

  **UI**
  - Added a Route Override entry in the More menu with a modal editor.
  - Added a Send-Override button next to Send, with a hover tooltip.